### PR TITLE
Updated npm dependancies to fix build conflicts.

### DIFF
--- a/.github/workflows/main_app-clarity-dev.yml
+++ b/.github/workflows/main_app-clarity-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v3
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: npm install, build, and test
         env:
@@ -47,7 +47,6 @@ jobs:
         with:
           name: node-app
           path: .
-          exclude: node_modules
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main_app-clarity-prod.yml
+++ b/.github/workflows/main_app-clarity-prod.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v3
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: npm install, build, and test
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@azure/storage-blob": "^12.29.1",
         "@supabase/supabase-js": "^2.90.1",
         "jose": "^5.9.0",
-        "next": "^16.1.6",
+        "next": "^16.2.3",
         "openai": "^4.0.0",
         "react": "^18.2.0",
         "react-calendly": "^4.4.0",
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@types/react": "19.2.7",
         "supabase": "^2.76.11",
-        "typescript": "5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2398,9 +2398,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@azure/storage-blob": "^12.29.1",
     "@supabase/supabase-js": "^2.90.1",
     "jose": "^5.9.0",
-    "next": "^16.1.6",
+    "next": "^16.2.3",
     "openai": "^4.0.0",
     "react": "^18.2.0",
     "react-calendly": "^4.4.0",
@@ -23,6 +23,6 @@
   "devDependencies": {
     "@types/react": "19.2.7",
     "supabase": "^2.76.11",
-    "typescript": "5.9.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
Updated node + typescript, and changed the listed version on the workflow (and in azure) to reflect the changes. Such that all of the versions are now the same npm 'node' 22.